### PR TITLE
TOOL-30782 drop the unused python3-future build dep for resolute

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Build-Depends:
 	libsnappy1v5,
 	libtool,
 	pkg-config,
-	python3-future,
 	python3-pyelftools,
 	python3-dev,
 	texinfo,


### PR DESCRIPTION
## Problem

`gdb-python` fails to build on Ubuntu 26.04 (resolute) in `build-packages/post-push` #5:

```
The following packages will be REMOVED:
  gdb-python-build-deps
mk-build-deps: Unable to install gdb-python-build-deps at /usr/bin/mk-build-deps line 470.
mk-build-deps: Unable to install all build-dep packages
```

`python3-future` is no longer published in resolute, so the dependency is unsatisfiable and apt resolves it by removing the generated build-deps package — which is what makes the error read as an install failure rather than a missing package.

## Solution

The solution is to drop it, because nothing uses it. No Python source in the tree imports the library (no `from builtins import`, no `from future`), and the only reference anywhere is this `Build-Depends` line — a leftover from the Python 2 to 3 era.

Checked the remaining 16 build deps against resolute's `main`/`universe`/`multiverse`/`restricted` package indexes (75,317 binary packages). The only other one absent from the archive is `libkdumpfile`, which is a Delphix package that `prepare()` installs from the dependency artifacts before `mk-build-deps` runs — confirmed in the build log fetching it from S3 — so it is not a gap.

This creates the repo's `os-upgrade` branch for the 26.04 cycle, from current `develop` (`ad9f60353`); it had been deleted in the 08-03 sweep, so the failing build was falling back to `develop` (`fatal: couldn't find remote ref os-upgrade` in the log).

## Testing Done

Not yet built; validated by the next `build-packages/post-push` `BUILD_POLICY=ALL` run. Results on TOOL-30782.