### PR TITLE
TOOL-30782 drop the unused python3-future build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Build-Depends:
 	libsnappy1v5,
 	libtool,
 	pkg-config,
-	python3-future,
 	python3-pyelftools,
 	python3-dev,
 	texinfo,


### PR DESCRIPTION
## Problem

`python3-future` is declared as a build dependency but nothing in the tree uses it. No Python source imports the library (no `from builtins import`, no `from future`), and the only reference to it anywhere is this `Build-Depends` line — a leftover from the Python 2 to 3 era.

It is still published in noble, so it costs nothing here today. Resolute drops the package, and an unsatisfiable build dep makes `mk-build-deps` **remove** the generated build-deps package rather than install it:

```
The following packages will be REMOVED:
  gdb-python-build-deps
mk-build-deps: Unable to install gdb-python-build-deps
```

## Solution

The solution is to drop it, since it is dead either way.

This is a **no-op on this branch** — `python3-future 0.18.2-6ubuntu2` is present in noble (verified against the develop mirror), so removing an unused dep changes nothing here. Already landed on `os-upgrade` ([#19](https://github.com/delphix/gdb-python/pull/19)), where it is load-bearing. Raising it here so it is one fewer change to re-land at the Ubuntu 26.04 cutover.

## Testing Done

Not separately built on this branch. Verified the dep is genuinely unused by grepping the whole tree for `future`/`builtins` imports (zero matches outside `debian/control`; the `debian/copyright` hits are GPL boilerplate). The identical change builds clean on `os-upgrade`.