### PR TITLE
TOOL-30782 build the C sources as gnu17 for resolute

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,20 @@
 
 SOURCE_NAME := $(shell dpkg-parsechangelog | sed -rne "s,^Source: (.*),\1,p")
 
+#
+# This tree, and the readline it bundles, predate C23. GCC 15 defaults to
+# -std=gnu23, where an empty parameter list means (void) instead of
+# "unspecified", so readline's unprototyped termcap declarations turn every
+# call into an error:
+#
+#   display.c:2805:17: error: too many arguments to function 'tputs';
+#       expected 0, have 3
+#
+# Build the C sources to the standard they were written against. This applies
+# to CFLAGS only, so gdb's C++ is untouched.
+#
+export DEB_CFLAGS_MAINT_APPEND = -std=gnu17
+
 %:
 	dh $@ --with python3
 


### PR DESCRIPTION
## Problem

With the `python3-future` build dep dropped ([#19](https://github.com/delphix/gdb-python/pull/19)), `mk-build-deps` now succeeds and the build proceeds to compiling — where it fails in the bundled readline:

```
display.c:2805:17: error: too many arguments to function 'tputs'; expected 0, have 3
display.c:3221:16: error: too many arguments to function 'tgoto'; expected 0, have 3
```

Dozens of these, all the same shape. GCC 15 defaults to `-std=gnu23`, where an empty parameter list `()` means `(void)` rather than "unspecified". readline declares the termcap entry points without prototypes, so calls that were always fine now read as passing 3 arguments to a 0-argument function.

## Solution

Pin the C standard to the one this code was written against:

```make
export DEB_CFLAGS_MAINT_APPEND = -std=gnu17
```

`DEB_CFLAGS_MAINT_APPEND` appends to `CFLAGS` only, so gdb's C++ is untouched — the failures are all in C.

**This is a mitigation, not a port.** The real fix is real prototypes, which belongs upstream in readline rather than in a Delphix packaging branch. Keeping it to a build flag also keeps it trivial to drop when this tree next takes an upstream refresh — worth doing eventually, since `-std=gnu17` will not hold forever.

## Testing Done

Not yet built. Validated by the next `build-packages/post-push` run on `os-upgrade`; results on TOOL-30782.